### PR TITLE
feature: 자신의 캐릭터 이동 시 다른 플레이어 화면에 실시간으로 반영

### DIFF
--- a/src/pages/Game/index.js
+++ b/src/pages/Game/index.js
@@ -31,13 +31,13 @@ export default function Game() {
     socketApi.enterGame(roomId);
 
     socket.on("send-room-players-info", playersInfo => {
-      const players = playersInfo.map(playerInfo => {
+      const playerList = playersInfo.map(playerInfo => {
         playerInfo.characterPath = characterSpriteSheet[playerInfo.characterType];
 
         return playerInfo;
       });
 
-      GameScene.set(player.id, roomId, players);
+      GameScene.set(player.id, roomId, playerList);
     });
   }, []);
 

--- a/src/pages/Game/index.js
+++ b/src/pages/Game/index.js
@@ -37,7 +37,7 @@ export default function Game() {
         return playerInfo;
       });
 
-      GameScene.set(players);
+      GameScene.set(player.id, roomId, players);
     });
   }, []);
 

--- a/src/phaser/scenes/MainScene.js
+++ b/src/phaser/scenes/MainScene.js
@@ -33,7 +33,9 @@ export default class MainScene extends Scene {
   create() {
     socket.on("send-move-player", player => {
       if (player.id !== this.id) {
-        this.players[player.id].play(player.id + player.anims, true);
+        const { id, currentDirection } = player;
+
+        this.players[player.id].anims.play(id + currentDirection, true);
         this.players[player.id].x = player.coordinateX;
         this.players[player.id].y = player.coordinateY;
       }
@@ -41,7 +43,9 @@ export default class MainScene extends Scene {
 
     socket.on("send-stop-player", player => {
       if (player.id !== this.id) {
-        this.players[player.id].anims.play(player.id + player.currentDirection);
+        const { id, currentDirection } = player;
+
+        this.players[player.id].anims.play(id + currentDirection);
         this.players[player.id].x = player.coordinateX;
         this.players[player.id].y = player.coordinateY;
       }
@@ -54,7 +58,9 @@ export default class MainScene extends Scene {
     this.createCursor();
 
     for (const player of this.playerList) {
-      this.createPlayers(player.id, player.coordinateX, player.coordinateY);
+      const { id, coordinateX, coordinateY } = player;
+
+      this.createPlayers(id, coordinateX, coordinateY);
     }
 
     this.cameras.main.setBounds(0, 0, 1920, 1080);

--- a/src/phaser/scenes/MainScene.js
+++ b/src/phaser/scenes/MainScene.js
@@ -9,14 +9,14 @@ export default class MainScene extends Scene {
     this.id = null;
     this.roomId = null;
     this.players = {};
-    this.playerList = null;
-    this.lastDirection = "down";
+    this.playerList = [];
+    this.currentDirection = "stop";
   }
 
-  set(id, roomId, playersInfo) {
+  set(id, roomId, playerList) {
     this.id = id;
     this.roomId = roomId;
-    this.playerList = playersInfo;
+    this.playerList = playerList;
   }
 
   preload() {
@@ -41,7 +41,7 @@ export default class MainScene extends Scene {
 
     socket.on("send-stop-player", player => {
       if (player.id !== this.id) {
-        this.players[player.id].anims.stop();
+        this.players[player.id].anims.play(player.id + player.currentDirection);
         this.players[player.id].x = player.coordinateX;
         this.players[player.id].y = player.coordinateY;
       }
@@ -133,7 +133,7 @@ export default class MainScene extends Scene {
     });
 
     this.anims.create({
-      key: key + "turn",
+      key: key + "stop",
       frames: [{ key: key, frame: 0 }],
       frameRate: 20,
     });
@@ -153,35 +153,35 @@ export default class MainScene extends Scene {
       this.players[this.id].setVelocityX(-160);
       this.players[this.id].anims.play(this.id + "left", true);
 
-      this.lastDirection = "left";
+      this.currentDirection = "left";
 
       this.handleMove();
     } else if (this.cursors.right.isDown) {
       this.players[this.id].setVelocityX(160);
       this.players[this.id].anims.play(this.id + "right", true);
 
-      this.lastDirection = "right";
+      this.currentDirection = "right";
 
       this.handleMove();
     } else if (this.cursors.up.isDown) {
       this.players[this.id].setVelocityY(-160);
       this.players[this.id].anims.play(this.id + "up", true);
 
-      this.lastDirection = "up";
+      this.currentDirection = "up";
 
       this.handleMove();
     } else if (this.cursors.down.isDown) {
       this.players[this.id].setVelocityY(160);
       this.players[this.id].anims.play(this.id + "down", true);
 
-      this.lastDirection = "down";
+      this.currentDirection = "down";
 
       this.handleMove();
     } else {
       this.players[this.id].setVelocityX(0);
       this.players[this.id].setVelocityY(0);
 
-      this.players[this.id].anims.play(this.id + this.lastDirection);
+      this.players[this.id].anims.play(this.id + this.currentDirection);
 
       this.handleStop();
     }
@@ -191,13 +191,13 @@ export default class MainScene extends Scene {
     const coordinateX = this.players[this.id].x;
     const coordinateY = this.players[this.id].y;
 
-    socketApi.pressArrowKeys(this.roomId, this.id, this.lastDirection, coordinateX, coordinateY);
+    socketApi.pressArrowKeys(this.roomId, this.id, this.currentDirection, coordinateX, coordinateY);
   }
 
   handleStop() {
     const coordinateX = this.players[this.id].x;
     const coordinateY = this.players[this.id].y;
 
-    socketApi.offArrowKeys(this.roomId, this.id, this.lastDirection, coordinateX, coordinateY);
+    socketApi.offArrowKeys(this.roomId, this.id, this.currentDirection, coordinateX, coordinateY);
   }
 }

--- a/src/utils/socket.js
+++ b/src/utils/socket.js
@@ -15,4 +15,10 @@ export const socketApi = {
   enterGame: roomId => {
     socket.emit("game-enter", roomId);
   },
+  pressArrowKeys: (roomId, playerId, anims, coordinateX, coordinateY) => {
+    socket.emit("player-move", { roomId, playerId, anims, coordinateX, coordinateY });
+  },
+  offArrowKeys: (roomId, playerId, anims, coordinateX, coordinateY) => {
+    socket.emit("player-stop", { roomId, playerId, anims, coordinateX, coordinateY });
+  },
 };

--- a/src/utils/socket.js
+++ b/src/utils/socket.js
@@ -15,10 +15,10 @@ export const socketApi = {
   enterGame: roomId => {
     socket.emit("game-enter", roomId);
   },
-  pressArrowKeys: (roomId, playerId, anims, coordinateX, coordinateY) => {
-    socket.emit("player-move", { roomId, playerId, anims, coordinateX, coordinateY });
+  pressArrowKeys: (roomId, playerId, currentDirection, coordinateX, coordinateY) => {
+    socket.emit("player-move", { roomId, playerId, currentDirection, coordinateX, coordinateY });
   },
-  offArrowKeys: (roomId, playerId, anims, coordinateX, coordinateY) => {
-    socket.emit("player-stop", { roomId, playerId, anims, coordinateX, coordinateY });
+  offArrowKeys: (roomId, playerId, currentDirection, coordinateX, coordinateY) => {
+    socket.emit("player-stop", { roomId, playerId, currentDirection, coordinateX, coordinateY });
   },
 };


### PR DESCRIPTION
## 작업사항

1. 캐릭터 이동할 때마다 캐릭터 방향과 좌표값 소켓 이벤트로 서버에 보내고 서버에서 다른 플레이어에게 해당 정보를 전송하여 플레이어 간에 실시간으로 캐릭터 이동 공유

## 체크리스트

- [ ] 로직이 적절한지
- [ ] 변수명, 함수명 적절한지

## 관련이슈

- 캐릭터가 이동할 때만 소켓으로 통신할 경우 상대방 화면에서 해당 캐릭터가 제자리에 있지만 움직이는 모션이 유지되어 캐릭터가 멈출 때도 소켓으로 통신하여 모션까지 멈추게 하였습니다.
- 캐릭터 이동 시 자신의 화면에서 다른 플레이어의 캐릭터의 sprite 이미지가 자신의 캐릭터 이미지로 변경이 되어서 단순히 "left", "right"로 이벤트 키값을 주지 않고 그 앞에 플레이어의 socket id를 붙여서 구분하였습니다.
- 방향키를 누르다 뗐을 때의 방향을 유지하기 위해서 lastDirection 속성을 주었습니다.