### PR TITLE
feature: 플레이어 닉네임 게임화면에 띄우기

### DIFF
--- a/src/pages/Game/index.js
+++ b/src/pages/Game/index.js
@@ -57,8 +57,9 @@ export default function Game() {
     if (isResultModalOpen) {
       const moveToMainScreen = setTimeout(() => {
         navigate("/");
-        clearTimeout(moveToMainScreen);
       }, 5000);
+
+      return () => clearTimeout(moveToMainScreen);
     }
   }, [isResultModalOpen]);
 

--- a/src/pages/Game/index.js
+++ b/src/pages/Game/index.js
@@ -1,8 +1,9 @@
 import Phaser from "phaser";
 import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { useParams } from "react-router-dom";
 import { useRecoilValue } from "recoil";
-import { modalState } from "../../states/modal";
+
 import Modal from "../Modal";
 import Video from "../../components/Video";
 import Time from "../../components/Time";
@@ -22,6 +23,7 @@ export default function Game() {
   const player = useRecoilValue(playerState);
   const [isShowVideoComponent, setIsShowVideoComponent] = useState(false);
   const { roomId } = useParams();
+  const navigate = useNavigate();
 
   useEffect(() => {
     new Phaser.Game(config);
@@ -41,9 +43,24 @@ export default function Game() {
         return playerInfo;
       });
 
-      GameScene.set(player.id, player.role, roomId, playerList);
+      GameScene.initialize(player.id, player.role, roomId, playerList);
     });
   }, []);
+
+  useEffect(() => {
+    if (!isPreloadModalOpen) {
+      GameScene.gameSet(true);
+    }
+  }, [isPreloadModalOpen]);
+
+  useEffect(() => {
+    if (isResultModalOpen) {
+      const moveToMainScreen = setTimeout(() => {
+        navigate("/");
+        clearTimeout(moveToMainScreen);
+      }, 5000);
+    }
+  }, [isResultModalOpen]);
 
   return (
     <>

--- a/src/phaser/config.js
+++ b/src/phaser/config.js
@@ -1,5 +1,6 @@
 import Phaser from "phaser";
 import MainScene from "./scenes/MainScene";
+
 export const GameScene = new MainScene();
 
 export const config = {

--- a/src/phaser/scenes/MainScene.js
+++ b/src/phaser/scenes/MainScene.js
@@ -11,8 +11,8 @@ export default class MainScene extends Scene {
     this.role = null;
     this.roomId = null;
     this.playerList = [];
-    this.spritePlayers = {};
-    this.spriteNicknames = {};
+    this.playerSprites = {};
+    this.nicknameSprites = {};
     this.currentDirection = "stop";
     this.isStart = false;
   }

--- a/src/phaser/scenes/MainScene.js
+++ b/src/phaser/scenes/MainScene.js
@@ -43,12 +43,12 @@ export default class MainScene extends Scene {
       if (player.id !== this.id) {
         const { id, currentDirection, coordinateX, coordinateY } = player;
 
-        this.spritePlayers[id].anims.play(id + currentDirection, true);
-        this.spritePlayers[id].x = coordinateX;
-        this.spritePlayers[id].y = coordinateY;
+        this.playerSprites[id].anims.play(id + currentDirection, true);
+        this.playerSprites[id].x = coordinateX;
+        this.playerSprites[id].y = coordinateY;
 
-        this.spriteNicknames[id].x = this.spritePlayers[id].body.position.x;
-        this.spriteNicknames[id].y = this.spritePlayers[id].body.position.y - 10;
+        this.nicknameSprites[id].x = this.playerSprites[id].body.position.x;
+        this.nicknameSprites[id].y = this.playerSprites[id].body.position.y - 10;
       }
     });
 
@@ -56,22 +56,22 @@ export default class MainScene extends Scene {
       if (player.id !== this.id) {
         const { id, currentDirection, coordinateX, coordinateY } = player;
 
-        this.spritePlayers[id].anims.play(id + currentDirection);
-        this.spritePlayers[id].x = coordinateX;
-        this.spritePlayers[id].y = coordinateY;
+        this.playerSprites[id].anims.play(id + currentDirection);
+        this.playerSprites[id].x = coordinateX;
+        this.playerSprites[id].y = coordinateY;
 
-        this.spriteNicknames[id].x = this.spritePlayers[id].body.position.x;
-        this.spriteNicknames[id].y = this.spritePlayers[id].body.position.y - 10;
+        this.nicknameSprites[id].x = this.playerSprites[id].body.position.x;
+        this.nicknameSprites[id].y = this.playerSprites[id].body.position.y - 10;
       }
     });
 
     socket.on("send-collided-player", playerId => {
-      this.spritePlayers[playerId].alpha === 1 ? (this.spritePlayers[playerId].alpha = 0.5) : (this.spritePlayers[playerId].alpha = 1);
+      this.playerSprites[playerId].alpha === 1 ? (this.playerSprites[playerId].alpha = 0.5) : (this.playerSprites[playerId].alpha = 1);
     });
 
     socket.on("send-arrested-player", playerId => {
-      this.spritePlayers[playerId].setVisible(false);
-      this.spriteNicknames[playerId].setVisible(false);
+      this.playerSprites[playerId].setVisible(false);
+      this.nicknameSprites[playerId].setVisible(false);
     });
 
     this.carGroup = this.add.group();
@@ -91,13 +91,13 @@ export default class MainScene extends Scene {
     }
 
     if (this.role === "police") {
-      this.physics.add.overlap(this.spritePlayers[this.id], this.carGroup, this.collideCar, null, this);
+      this.physics.add.overlap(this.playerSprites[this.id], this.carGroup, this.collideCar, null, this);
     } else {
-      this.physics.add.overlap(this.spritePlayers[this.id], this.policeGroup, this.arrest, null, this);
+      this.physics.add.overlap(this.playerSprites[this.id], this.policeGroup, this.arrest, null, this);
     }
 
     this.cameras.main.setBounds(0, 0, 1920, 1080);
-    this.cameras.main.startFollow(this.spritePlayers[this.id], true, 0.09, 0.09);
+    this.cameras.main.startFollow(this.playerSprites[this.id], true, 0.09, 0.09);
 
     this.cameras.main.setZoom(2);
   }
@@ -138,19 +138,19 @@ export default class MainScene extends Scene {
   }
 
   createPlayers(key, nickname, role, coordinateX, coordinateY) {
-    this.spritePlayers[key] = this.physics.add.sprite(coordinateX, coordinateY, key).setScale(2, 2).refreshBody();
+    this.playerSprites[key] = this.physics.add.sprite(coordinateX, coordinateY, key).setScale(2, 2).refreshBody();
 
     const color = this.role === role ? "blue" : "red";
-    this.spriteNicknames[key] = this.add.text(this.spritePlayers[key].x, this.spritePlayers[key].y - 10, nickname, { fontSize: "16px", color: color, align: "center" });
+    this.nicknameSprites[key] = this.add.text(this.playerSprites[key].x, this.playerSprites[key].y - 10, nickname, { fontSize: "16px", color: color, align: "center" });
 
-    this.spritePlayers[key].setBounce(0.2);
-    this.spritePlayers[key].setCollideWorldBounds(true);
+    this.playerSprites[key].setBounce(0.2);
+    this.playerSprites[key].setCollideWorldBounds(true);
     this.physics.world.bounds.setTo(0, 500, config.width, config.height - 500);
 
     if (role === "police") {
-      this.policeGroup.add(this.spritePlayers[key]);
+      this.policeGroup.add(this.playerSprites[key]);
     } else {
-      this.robberGroup.add(this.spritePlayers[key]);
+      this.robberGroup.add(this.playerSprites[key]);
     }
 
     this.anims.create({
@@ -199,54 +199,54 @@ export default class MainScene extends Scene {
 
   managePlayerMovement(key) {
     if (this.isStart) {
-      if (this.cursors.left.isDown && this.spritePlayers[key].alpha === 1) {
-        this.spritePlayers[key].setVelocityX(-160);
-        this.spritePlayers[key].anims.play(key + "left", true);
+      if (this.cursors.left.isDown && this.playerSprites[key].alpha === 1) {
+        this.playerSprites[key].setVelocityX(-160);
+        this.playerSprites[key].anims.play(key + "left", true);
 
         this.currentDirection = "left";
-      } else if (this.cursors.right.isDown && this.spritePlayers[key].alpha === 1) {
-        this.spritePlayers[key].setVelocityX(160);
-        this.spritePlayers[key].anims.play(key + "right", true);
+      } else if (this.cursors.right.isDown && this.playerSprites[key].alpha === 1) {
+        this.playerSprites[key].setVelocityX(160);
+        this.playerSprites[key].anims.play(key + "right", true);
 
         this.currentDirection = "right";
-      } else if (this.cursors.up.isDown && this.spritePlayers[key].alpha === 1) {
-        this.spritePlayers[key].setVelocityY(-160);
-        this.spritePlayers[key].anims.play(key + "up", true);
+      } else if (this.cursors.up.isDown && this.playerSprites[key].alpha === 1) {
+        this.playerSprites[key].setVelocityY(-160);
+        this.playerSprites[key].anims.play(key + "up", true);
 
         this.currentDirection = "up";
-      } else if (this.cursors.down.isDown && this.spritePlayers[key].alpha === 1) {
-        this.spritePlayers[key].setVelocityY(160);
-        this.spritePlayers[key].anims.play(key + "down", true);
+      } else if (this.cursors.down.isDown && this.playerSprites[key].alpha === 1) {
+        this.playerSprites[key].setVelocityY(160);
+        this.playerSprites[key].anims.play(key + "down", true);
 
         this.currentDirection = "down";
       } else {
-        this.spritePlayers[key].setVelocity(0);
+        this.playerSprites[key].setVelocity(0);
 
-        this.spritePlayers[key].anims.play(key + this.currentDirection);
+        this.playerSprites[key].anims.play(key + this.currentDirection);
 
-        this.spriteNicknames[key].x = this.spritePlayers[key].body.position.x;
-        this.spriteNicknames[key].y = this.spritePlayers[key].body.position.y - 10;
+        this.nicknameSprites[key].x = this.playerSprites[key].body.position.x;
+        this.nicknameSprites[key].y = this.playerSprites[key].body.position.y - 10;
 
         return this.handleStop();
       }
     }
 
-    this.spriteNicknames[key].x = this.spritePlayers[key].body.position.x;
-    this.spriteNicknames[key].y = this.spritePlayers[key].body.position.y - 10;
+    this.nicknameSprites[key].x = this.playerSprites[key].body.position.x;
+    this.nicknameSprites[key].y = this.playerSprites[key].body.position.y - 10;
 
     this.handleMove();
   }
 
   handleMove() {
-    const coordinateX = this.spritePlayers[this.id].x;
-    const coordinateY = this.spritePlayers[this.id].y;
+    const coordinateX = this.playerSprites[this.id].x;
+    const coordinateY = this.playerSprites[this.id].y;
 
     socketApi.pressArrowKeys(this.roomId, this.id, this.currentDirection, coordinateX, coordinateY);
   }
 
   handleStop() {
-    const coordinateX = this.spritePlayers[this.id].x;
-    const coordinateY = this.spritePlayers[this.id].y;
+    const coordinateX = this.playerSprites[this.id].x;
+    const coordinateY = this.playerSprites[this.id].y;
 
     socketApi.offArrowKeys(this.roomId, this.id, this.currentDirection, coordinateX, coordinateY);
   }
@@ -266,7 +266,7 @@ export default class MainScene extends Scene {
   arrest() {
     socketApi.arrestRobber(this.roomId, this.id);
 
-    this.cameras.main.startFollow(this.spritePlayers[this.id], false, 0.09, 0.09);
+    this.cameras.main.startFollow(this.playerSprites[this.id], false, 0.09, 0.09);
     this.cameras.main.setZoom(1);
   }
 }

--- a/src/phaser/scenes/MainScene.js
+++ b/src/phaser/scenes/MainScene.js
@@ -6,19 +6,26 @@ import { socket, socketApi } from "../../utils/socket";
 export default class MainScene extends Scene {
   constructor() {
     super({ key: "MainScene" });
+
     this.id = null;
     this.role = null;
     this.roomId = null;
-    this.players = {};
     this.playerList = [];
+    this.spritePlayers = {};
+    this.spriteNicknames = {};
     this.currentDirection = "stop";
+    this.isStart = false;
   }
 
-  set(id, role, roomId, playerList) {
+  initialize(id, role, roomId, playerList) {
     this.id = id;
     this.role = role;
     this.roomId = roomId;
     this.playerList = playerList;
+  }
+
+  gameSet(isStart) {
+    this.isStart = isStart;
   }
 
   preload() {
@@ -36,9 +43,12 @@ export default class MainScene extends Scene {
       if (player.id !== this.id) {
         const { id, currentDirection, coordinateX, coordinateY } = player;
 
-        this.players[player.id].anims.play(id + currentDirection, true);
-        this.players[player.id].x = coordinateX;
-        this.players[player.id].y = coordinateY;
+        this.spritePlayers[id].anims.play(id + currentDirection, true);
+        this.spritePlayers[id].x = coordinateX;
+        this.spritePlayers[id].y = coordinateY;
+
+        this.spriteNicknames[id].x = this.spritePlayers[id].body.position.x;
+        this.spriteNicknames[id].y = this.spritePlayers[id].body.position.y - 10;
       }
     });
 
@@ -46,18 +56,22 @@ export default class MainScene extends Scene {
       if (player.id !== this.id) {
         const { id, currentDirection, coordinateX, coordinateY } = player;
 
-        this.players[id].anims.play(id + currentDirection);
-        this.players[id].x = coordinateX;
-        this.players[id].y = coordinateY;
+        this.spritePlayers[id].anims.play(id + currentDirection);
+        this.spritePlayers[id].x = coordinateX;
+        this.spritePlayers[id].y = coordinateY;
+
+        this.spriteNicknames[id].x = this.spritePlayers[id].body.position.x;
+        this.spriteNicknames[id].y = this.spritePlayers[id].body.position.y - 10;
       }
     });
 
     socket.on("send-collided-player", playerId => {
-      this.players[playerId].alpha === 1 ? (this.players[playerId].alpha = 0.5) : (this.players[playerId].alpha = 1);
+      this.spritePlayers[playerId].alpha === 1 ? (this.spritePlayers[playerId].alpha = 0.5) : (this.spritePlayers[playerId].alpha = 1);
     });
 
     socket.on("send-arrested-player", playerId => {
-      this.players[playerId].setVisible(false);
+      this.spritePlayers[playerId].setVisible(false);
+      this.spriteNicknames[playerId].setVisible(false);
     });
 
     this.carGroup = this.add.group();
@@ -71,19 +85,19 @@ export default class MainScene extends Scene {
     this.createCursor();
 
     for (const player of this.playerList) {
-      const { id, role, coordinateX, coordinateY } = player;
+      const { id, nickname, role, coordinateX, coordinateY } = player;
 
-      this.createPlayers(id, role, coordinateX, coordinateY);
+      this.createPlayers(id, nickname, role, coordinateX, coordinateY);
     }
 
     if (this.role === "police") {
-      this.physics.add.overlap(this.players[this.id], this.carGroup, this.collideCar, null, this);
+      this.physics.add.overlap(this.spritePlayers[this.id], this.carGroup, this.collideCar, null, this);
     } else {
-      this.physics.add.overlap(this.players[this.id], this.policeGroup, this.arrest, null, this);
+      this.physics.add.overlap(this.spritePlayers[this.id], this.policeGroup, this.arrest, null, this);
     }
 
     this.cameras.main.setBounds(0, 0, 1920, 1080);
-    this.cameras.main.startFollow(this.players[this.id], true, 0.09, 0.09);
+    this.cameras.main.startFollow(this.spritePlayers[this.id], true, 0.09, 0.09);
 
     this.cameras.main.setZoom(2);
   }
@@ -94,10 +108,10 @@ export default class MainScene extends Scene {
   }
 
   createCars() {
-    this.redcar = this.physics.add.sprite(400, 700, "redcar").setScale(0.5, 0.5);
-    this.bluecar = this.physics.add.sprite(500, 750, "bluecar").setScale(0.5, 0.5);
-    this.greencar = this.physics.add.sprite(600, 750, "greencar").setScale(0.5, 0.5);
-    this.yellowcar = this.physics.add.sprite(700, 810, "yellowcar").setScale(0.5, 0.5);
+    this.redcar = this.physics.add.sprite(0, 700, "redcar").setScale(0.5, 0.5).setVelocityX(400);
+    this.bluecar = this.physics.add.sprite(0, 750, "bluecar").setScale(0.5, 0.5).setVelocityX(600);
+    this.greencar = this.physics.add.sprite(0, 750, "greencar").setScale(0.5, 0.5).setVelocityX(300);
+    this.yellowcar = this.physics.add.sprite(0, 810, "yellowcar").setScale(0.5, 0.5).setVelocityX(800);
 
     this.carGroup.add(this.redcar);
     this.carGroup.add(this.bluecar);
@@ -109,9 +123,7 @@ export default class MainScene extends Scene {
     this.cursors = this.input.keyboard.createCursorKeys();
   }
 
-  moveCar(car, speed) {
-    car.x += speed;
-
+  moveCar(car) {
     if (car.x > config.width) {
       car.x = 0;
     }
@@ -125,17 +137,20 @@ export default class MainScene extends Scene {
     });
   }
 
-  createPlayers(key, role, coordinateX, coordinateY) {
-    this.players[key] = this.physics.add.sprite(coordinateX, coordinateY, key).setScale(2, 2).refreshBody();
+  createPlayers(key, nickname, role, coordinateX, coordinateY) {
+    this.spritePlayers[key] = this.physics.add.sprite(coordinateX, coordinateY, key).setScale(2, 2).refreshBody();
 
-    this.players[key].setBounce(0.2);
-    this.players[key].setCollideWorldBounds(true);
+    const color = this.role === role ? "blue" : "red";
+    this.spriteNicknames[key] = this.add.text(this.spritePlayers[key].x, this.spritePlayers[key].y - 10, nickname, { fontSize: "16px", color: color, align: "center" });
+
+    this.spritePlayers[key].setBounce(0.2);
+    this.spritePlayers[key].setCollideWorldBounds(true);
     this.physics.world.bounds.setTo(0, 500, config.width, config.height - 500);
 
     if (role === "police") {
-      this.policeGroup.add(this.players[key]);
+      this.policeGroup.add(this.spritePlayers[key]);
     } else {
-      this.robberGroup.add(this.players[key]);
+      this.robberGroup.add(this.spritePlayers[key]);
     }
 
     this.anims.create({
@@ -174,56 +189,64 @@ export default class MainScene extends Scene {
   }
 
   update() {
-    this.moveCar(this.redcar, 9);
-    this.moveCar(this.bluecar, 6);
-    this.moveCar(this.greencar, 5);
-    this.moveCar(this.yellowcar, 6);
+    this.moveCar(this.redcar);
+    this.moveCar(this.bluecar);
+    this.moveCar(this.greencar);
+    this.moveCar(this.yellowcar);
 
     this.managePlayerMovement(this.id);
   }
 
   managePlayerMovement(key) {
-    if (this.cursors.left.isDown && this.players[key].alpha === 1) {
-      this.players[key].setVelocityX(-160);
-      this.players[key].anims.play(key + "left", true);
+    if (this.isStart) {
+      if (this.cursors.left.isDown && this.spritePlayers[key].alpha === 1) {
+        this.spritePlayers[key].setVelocityX(-160);
+        this.spritePlayers[key].anims.play(key + "left", true);
 
-      this.currentDirection = "left";
-    } else if (this.cursors.right.isDown && this.players[key].alpha === 1) {
-      this.players[key].setVelocityX(160);
-      this.players[key].anims.play(key + "right", true);
+        this.currentDirection = "left";
+      } else if (this.cursors.right.isDown && this.spritePlayers[key].alpha === 1) {
+        this.spritePlayers[key].setVelocityX(160);
+        this.spritePlayers[key].anims.play(key + "right", true);
 
-      this.currentDirection = "right";
-    } else if (this.cursors.up.isDown && this.players[key].alpha === 1) {
-      this.players[key].setVelocityY(-160);
-      this.players[key].anims.play(key + "up", true);
+        this.currentDirection = "right";
+      } else if (this.cursors.up.isDown && this.spritePlayers[key].alpha === 1) {
+        this.spritePlayers[key].setVelocityY(-160);
+        this.spritePlayers[key].anims.play(key + "up", true);
 
-      this.currentDirection = "up";
-    } else if (this.cursors.down.isDown && this.players[key].alpha === 1) {
-      this.players[key].setVelocityY(160);
-      this.players[key].anims.play(key + "down", true);
+        this.currentDirection = "up";
+      } else if (this.cursors.down.isDown && this.spritePlayers[key].alpha === 1) {
+        this.spritePlayers[key].setVelocityY(160);
+        this.spritePlayers[key].anims.play(key + "down", true);
 
-      this.currentDirection = "down";
-    } else {
-      this.players[key].setVelocity(0);
+        this.currentDirection = "down";
+      } else {
+        this.spritePlayers[key].setVelocity(0);
 
-      this.players[key].anims.play(key + this.currentDirection);
+        this.spritePlayers[key].anims.play(key + this.currentDirection);
 
-      return this.handleStop();
+        this.spriteNicknames[key].x = this.spritePlayers[key].body.position.x;
+        this.spriteNicknames[key].y = this.spritePlayers[key].body.position.y - 10;
+
+        return this.handleStop();
+      }
     }
+
+    this.spriteNicknames[key].x = this.spritePlayers[key].body.position.x;
+    this.spriteNicknames[key].y = this.spritePlayers[key].body.position.y - 10;
 
     this.handleMove();
   }
 
   handleMove() {
-    const coordinateX = this.players[this.id].x;
-    const coordinateY = this.players[this.id].y;
+    const coordinateX = this.spritePlayers[this.id].x;
+    const coordinateY = this.spritePlayers[this.id].y;
 
     socketApi.pressArrowKeys(this.roomId, this.id, this.currentDirection, coordinateX, coordinateY);
   }
 
   handleStop() {
-    const coordinateX = this.players[this.id].x;
-    const coordinateY = this.players[this.id].y;
+    const coordinateX = this.spritePlayers[this.id].x;
+    const coordinateY = this.spritePlayers[this.id].y;
 
     socketApi.offArrowKeys(this.roomId, this.id, this.currentDirection, coordinateX, coordinateY);
   }
@@ -243,7 +266,7 @@ export default class MainScene extends Scene {
   arrest() {
     socketApi.arrestRobber(this.roomId, this.id);
 
-    this.cameras.main.startFollow(this.players[this.id], false, 0.09, 0.09);
+    this.cameras.main.startFollow(this.spritePlayers[this.id], false, 0.09, 0.09);
     this.cameras.main.setZoom(1);
   }
 }

--- a/src/utils/socket.js
+++ b/src/utils/socket.js
@@ -27,15 +27,6 @@ export const socketApi = {
   arrestRobber: (roomId, playerId) => {
     socket.emit("arrest-robber", { roomId, playerId });
   },
-  findCurrentJoiningRoom: roomId => {
-    socket.emit("find-current-joining-room", roomId);
-  },
-  sendingSignalToConnectWebRTC: (teamplayerId, socketId, signal) => {
-    socket.emit("sending-signal-to-connect-webRTC", { userToSignal: teamplayerId, callerID: socketId, signal });
-  },
-  returningSignalToConnectWebRTC: (signal, callerID) => {
-    socket.emit("returning-signal-to-connect-webRTC", { signal, callerID });
-  },
   leaveRoom: (roomId, role, id, isHost) => {
     socket.emit("leave-room", { roomId, role, id, isHost });
   },
@@ -53,8 +44,5 @@ export const socketApi = {
   },
   sendingSignalToConnectWebRTC: payload => {
     socket.emit("sending-signal-to-connect-webRTC", { userToSignal: payload.userToSignal, callerID: payload.callerID, signal: payload.signal });
-  },
-  findCurrentJoiningRoom: roomId => {
-    socket.emit("find-current-joining-room", roomId);
   },
 };


### PR DESCRIPTION
- 카운트다운 동안 플레이어 움직임 제한
- 게임 종료 후 5초 뒤 메인화면으로 이동

## 작업사항

1. 플레이어가 설정한 닉네임 텍스트가 캐릭터 위에 위치합니다.
2. 아군의 경우 닉네임이 파란색, 적군의 경우 빨간색으로 보입니다.
3. 카운트다운 동안 플레이어의 움직임이 제한됩니다.
4. 게임 종료 후 5초 뒤 메인화면으로 이동합니다.

## 체크리스트

- [ ] 불필요한 로직은 없는지
- [ ] 변수명 및 함수명 적절한지

## 관련이슈

- 닉네임 텍스트의 위치가 캐릭터 위치에 기반해서 정해지기 때문에 현재 한쪽으로 쏠려있는데 캐릭터의 정 중앙에 위치할 수 있게끔 수정해야 합니다.
