### PR TITLE
refactor: 방을 만들고 다시 다른방으로 들어가면 그방에서도 방장의 권한이 유지되는 기능 수정

### DIFF
--- a/src/pages/CreatePlayer/index.js
+++ b/src/pages/CreatePlayer/index.js
@@ -47,14 +47,12 @@ export default function CreatePlayer() {
   const createRoom = () => {
     socketApi.assignRoomCreatorAsHost({
       ...player,
-      isHost: true,
     });
 
     socket.on(SEND_SOCKET_ID, socketId => {
       setPlayer({
         ...player,
         id: socketId,
-        isHost: true,
       });
     });
 

--- a/src/pages/Standby/index.js
+++ b/src/pages/Standby/index.js
@@ -7,7 +7,8 @@ import styled from "styled-components";
 
 export default function Standby() {
   const [roleCount, setRoleCount] = useState({});
-  const { id, role, isHost } = useRecoilValue(playerState);
+  const { id, role } = useRecoilValue(playerState);
+  const [isHost, setIsHost] = useState(false);
   const { roomId } = useParams();
   const navigate = useNavigate();
 
@@ -21,9 +22,11 @@ export default function Standby() {
     socket.on("leave-room-player-redirect-room-list", () => navigate("/room/list"));
   }, []);
 
-  const handleRunButton = roomId => {
-    socketApi.handleRunButton(roomId);
-  };
+  useEffect(() => {
+    id === roomId ? setIsHost(true) : setIsHost(false);
+  }, [id]);
+
+  const handleRunButton = roomId => socketApi.handleRunButton(roomId);
 
   const handleExitButton = (roomId, role, id, isHost) => {
     socketApi.leaveRoom(roomId, role, id, isHost);

--- a/src/states/player.js
+++ b/src/states/player.js
@@ -5,7 +5,6 @@ export const playerState = atom({
   default: {
     id: "",
     role: "police",
-    isHost: false,
     nickname: "",
     characterType: "police1",
   },


### PR DESCRIPTION
## 작업사항

1. player atom에서 isHost 삭제
2. 대기화면에서 id와 roomId를 비교하여 방장 권한 부여

## 체크리스트

- [ ] 대기화면에서 방장여부를 부여하는것이 올바른지
- [ ] dependency를 id로 주었는데 괜찮은지

## 관련이슈

- isHost라는 값은 대기화면에서 방장여부만확인하므로 방장여부를 대기화면에서 id와 roomId를 부여하여 비교하였습니다.
