### PR TITLE
refactor: characterpath 넘겨주는 로직 추가

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -7,5 +7,5 @@
   "trailingComma": "es5",
   "arrowParens": "avoid",
   "endOfLine": "auto",
-  "printWidth": 300
+  "printWidth": 150
 }

--- a/src/constants/phaser.js
+++ b/src/constants/phaser.js
@@ -7,7 +7,7 @@ export const POLICE_OPACITY_CHANGED = "police-opacity-changed";
 export const SEND_COLLIDED_PLAYER = "send-collided-player";
 export const ARREST_ROBBER = "arrest-robber";
 
-export const FIND_CURRENT_JOINING_ROOM = "find-current-joining-room";
+export const FIND_ENTERED_ROOM = "find-entered-room";
 export const RETURNING_SIGNAL_TO_CONNECT_WEBRTC = "returning-signal-to-connect-webRTC";
 export const SENDING_SIGNAL_TO_CONNECT_WEBRTC = "sending-signal-to-connect-webRTC";
 export const SET_VIDEO = "set-video";
@@ -17,4 +17,4 @@ export const CLOSE_VIDEO = "close-video";
 export const SEND_SOCKET_ID = "send-socket-id";
 export const SEND_ROOM_PLAYERS_INFORMATION = "send-room-players-info";
 export const SEND_ARRESTED_PLAYER = "send-arrested-player";
-export const SEND_LEFT_PLAYER = "send-left-player";
+export const SEND_EXIT_PLAYER = "send-exit-player";

--- a/src/pages/CreatePlayer/index.js
+++ b/src/pages/CreatePlayer/index.js
@@ -3,7 +3,7 @@ import { useNavigate } from "react-router-dom";
 import { useRecoilState } from "recoil";
 import styled from "styled-components";
 
-import { characterImage as character } from "../../constants/assets";
+import { characterImage as character, characterSpriteSheet } from "../../constants/assets";
 import { SEND_SOCKET_ID } from "../../constants/phaser";
 import { socket, socketApi } from "../../utils/socket";
 import { playerState } from "../../states/player";
@@ -38,9 +38,13 @@ export default function CreatePlayer() {
   };
 
   useEffect(() => {
+    const characterType = characterImages[index].alias;
+    const characterPath = characterSpriteSheet[characterType];
+
     setPlayer({
       ...player,
-      characterType: characterImages[index].alias,
+      characterPath,
+      characterType,
     });
   }, [index, characterImages]);
 

--- a/src/pages/Standby/index.js
+++ b/src/pages/Standby/index.js
@@ -12,6 +12,8 @@ export default function Standby() {
   const { roomId } = useParams();
   const navigate = useNavigate();
 
+  const { policeCount, robberCount } = roleCount;
+
   useEffect(() => {
     socketApi.standby(roomId);
 
@@ -44,11 +46,11 @@ export default function Standby() {
         />
         <p className="description">Waiting for other players . . .</p>
         <div className="count-wrap">
-          <p>경찰 {roleCount.police}</p>
-          <p>도둑 {roleCount.robber}</p>
+          <p>경찰 {policeCount}</p>
+          <p>도둑 {robberCount}</p>
         </div>
         <div className="game-start-button-wrap">
-          {roleCount.police > 0 && roleCount.robber > 0 && isHost && (
+          {policeCount > 0 && robberCount > 0 && isHost && (
             <button
               type="button"
               onClick={() => {

--- a/src/utils/socket.js
+++ b/src/utils/socket.js
@@ -1,6 +1,25 @@
 import io from "socket.io-client";
-import { ASSIGN_ROOM_CREATOR_AS_HOST, ENTER_GAME, ENTER_ROOM_LIST, JOIN_ROOM, LEAVE_ROOM, LEAVE_GAME, HANDLE_RUN_BUTTON, STANDBY } from "../constants/socket";
-import { ARREST_ROBBER, POLICE_OPACITY_CHANGED, FIND_CURRENT_JOINING_ROOM, OPEN_VIDEO, CLOSE_VIDEO, PLAYER_MOVE, PLAYER_STOP, RETURNING_SIGNAL_TO_CONNECT_WEBRTC, SENDING_SIGNAL_TO_CONNECT_WEBRTC } from "../constants/phaser";
+import {
+  STANDBY,
+  ENTER_GAME,
+  JOIN_ROOM,
+  LEAVE_ROOM,
+  LEAVE_GAME,
+  ENTER_ROOM_LIST,
+  HANDLE_RUN_BUTTON,
+  ASSIGN_ROOM_CREATOR_AS_HOST,
+} from "../constants/socket";
+import {
+  OPEN_VIDEO,
+  CLOSE_VIDEO,
+  PLAYER_MOVE,
+  PLAYER_STOP,
+  ARREST_ROBBER,
+  FIND_ENTERED_ROOM,
+  POLICE_OPACITY_CHANGED,
+  SENDING_SIGNAL_TO_CONNECT_WEBRTC,
+  RETURNING_SIGNAL_TO_CONNECT_WEBRTC,
+} from "../constants/phaser";
 
 export const socket = io.connect(process.env.REACT_APP_SERVER_URL);
 
@@ -41,8 +60,8 @@ export const socketApi = {
   leaveGame: (roomId, playerId, playerRole) => {
     socket.emit(LEAVE_GAME, { roomId, playerId, playerRole });
   },
-  findCurrentJoiningRoom: roomId => {
-    socket.emit(FIND_CURRENT_JOINING_ROOM, roomId);
+  findEnteredRoom: roomId => {
+    socket.emit(FIND_ENTERED_ROOM, roomId);
   },
   returningSignalToConnectWebRTC: payload => {
     const { signal, callerID } = payload;


### PR DESCRIPTION
## 작업사항

1. (수정 전) character spritesheet의 이미지 경로는 프론트에 존재하기 때문에 게임이 시작하기 직전 characterpath를 추가해주는 로직이 존재하였음.
2. (수정 후) 백엔드에서 플레이 정보를 소켓으로 받아오기 이전에 characterpath를 추가해주는 로직을 작성하였음.
3. 로직 간소화
